### PR TITLE
fix(SemverSettings): Allow dashes as part of scope names

### DIFF
--- a/src/main/kotlin/git/semver/plugin/semver/SemverSettings.kt
+++ b/src/main/kotlin/git/semver/plugin/semver/SemverSettings.kt
@@ -4,9 +4,9 @@ open class SemverSettings {
 
     var defaultPreRelease: String = "SNAPSHOT"
     var releasePattern: String = "\\Arelease(?:\\(\\w+\\))?:"
-    var patchPattern: String = "\\Afix(?:\\(\\w+\\))?:"
-    var minorPattern: String = "\\Afeat(?:\\(\\w+\\))?:"
-    var majorPattern: String = "\\A\\w+(?:\\(\\w+\\))?!:|^BREAKING[ -]CHANGE:"
+    var patchPattern: String = "\\Afix(?:\\([\\w-]+\\))?:"
+    var minorPattern: String = "\\Afeat(?:\\([\\w-]+\\))?:"
+    var majorPattern: String = "\\A\\w+(?:\\([\\w-]+\\))?!:|^BREAKING[ -]CHANGE:"
     var releaseCommitTextFormat = "release: v%s\n\n%s"
     var releaseTagNameFormat = "%s"
     var groupVersionIncrements = true


### PR DESCRIPTION
A scope like "misc-utils" should be valid.