### PR TITLE
fix(VersionFinder): Do not throw if only non-version tags are present

### DIFF
--- a/src/main/kotlin/git/semver/plugin/semver/VersionFinder.kt
+++ b/src/main/kotlin/git/semver/plugin/semver/VersionFinder.kt
@@ -107,6 +107,6 @@ class VersionFinder(private val settings: SemverSettings, private val tags: Map<
         return if (SemVersion.isRelease(commit, settings))
             SemVersion.tryParse(commit)
         else
-            tags[commit.sha]?.mapNotNull(SemVersion.Companion::tryParse)?.max()
+            tags[commit.sha]?.mapNotNull(SemVersion::tryParse)?.maxOrNull()
     }
 }

--- a/src/test/kotlin/git/semver/plugin/semver/VersionFinderTest.kt
+++ b/src/test/kotlin/git/semver/plugin/semver/VersionFinderTest.kt
@@ -141,6 +141,20 @@ class VersionFinderTest {
     }
 
     @Test
+    fun one_commit_no_version_tags() {
+        // given
+        val commits = listOf(FIRST)
+        val tags = listOf(Tag("dummy", FIRST))
+
+        // when
+        val versions = getVersion(tags, asCommit(commits))
+
+        // then
+        assertEquals("0.0.1-SNAPSHOT", versions.toVersionString())
+        assertEquals("0.0.1-SNAPSHOT+001", versions.toInfoVersionString())
+    }
+
+    @Test
     fun one_commit_one_tag() {
         // given
         val commits = listOf(FIRST)


### PR DESCRIPTION
While at it, trivially simplify code by omitting ".Companion".