### PR TITLE
docs: Trivially improve the wording about the created tag

### DIFF
--- a/src/main/kotlin/git/semver/plugin/scm/GitProvider.kt
+++ b/src/main/kotlin/git/semver/plugin/scm/GitProvider.kt
@@ -87,7 +87,7 @@ class GitProvider(private val settings: SemverSettings) {
         if (tag && settings.releaseTagNameFormat.isNotEmpty()) {
             val name = settings.releaseTagNameFormat.format(versionString)
             it.tag().setName(name).setMessage(message).call()
-            println("New tag: $name")
+            println("Created new local Git tag: $name")
         }
     }
 


### PR DESCRIPTION
Make more clear that the tag was actually created, but only locally, and not pushed to a remote.