### PR TITLE
docs(ReleaseTask): Clarify task description a bit

### DIFF
--- a/src/main/kotlin/git/semver/plugin/gradle/ReleaseTask.kt
+++ b/src/main/kotlin/git/semver/plugin/gradle/ReleaseTask.kt
@@ -17,7 +17,7 @@ open class ReleaseTask @Inject constructor(private val settings: GitSemverPlugin
 
     init {
         group = GitSemverPlugin.VERSIONING_GROUP
-        description = "Creates a release commit and tag"
+        description = "Creates a release commit and / or local tag"
     }
 
     @Option(option = "preRelease", description = "Set the current preRelease")


### PR DESCRIPTION
Depending on configuration, not always a commit *and* tag is created. Also emphasize that the tag is only created locally (and not pushed).