### PR TITLE
chore(ChangeLogSettings): Use full-length SHA1s by default

### DIFF
--- a/src/main/kotlin/git/semver/plugin/changelog/ChangeLogSettings.kt
+++ b/src/main/kotlin/git/semver/plugin/changelog/ChangeLogSettings.kt
@@ -1,6 +1,6 @@
 package git.semver.plugin.changelog
 
-class ChangeLogSettings(
+data class ChangeLogSettings(
     var header: String? = null,
     var breakingChangeHeader: String? = null,
     var otherChangeHeader: String? = null,
@@ -9,7 +9,7 @@ class ChangeLogSettings(
     var changePrefix: String = "",
     var changePostfix: String = "",
     var changeLineSeparator: String? = null,
-    var changeShaLength: Int = 7,
+    var changeShaLength: Int = 40,
     var groupStart: String? = null,
     var groupEnd: String? = null,
     var footer: String? = null

--- a/src/test/kotlin/git/semver/plugin/changelog/ChangeLogFormatterTest.kt
+++ b/src/test/kotlin/git/semver/plugin/changelog/ChangeLogFormatterTest.kt
@@ -20,7 +20,10 @@ class ChangeLogFormatterTest {
         val changeLog = createChangeLog()
         val settings = SemverSettings()
 
-        val actual = ChangeLogFormatter(settings, ChangeLogSettings.defaultChangeLog).formatLog(changeLog)
+        val actual = ChangeLogFormatter(
+            settings,
+            ChangeLogSettings.defaultChangeLog.copy(changeShaLength = 7)
+        ).formatLog(changeLog)
 
         assertThat(actual)
             .startsWith("## What's Changed")


### PR DESCRIPTION
Sometimes GitHub is not able to automatically resolve short SHA1s to commits as part of its release notes, so use full SHA1s instead; they will only be rendered as short SHA1s as part of notes attched to GitHub releases anyway.