### PR TITLE
Move public ChangeLogFormat constants into the companion object

### DIFF
--- a/src/main/kotlin/git/semver/plugin/changelog/ChangeLogFormat.kt
+++ b/src/main/kotlin/git/semver/plugin/changelog/ChangeLogFormat.kt
@@ -7,10 +7,6 @@ private const val SCOPE = "Scope"
 private const val TYPE = "Type"
 private const val MESSAGE = "Message"
 
-const val HEADER = "#"
-const val BREAKING_CHANGE = "!"
-const val OTHER_CHANGE = "?"
-
 data class ChangeLogFormat(
     val groupByText: Boolean = true,
     val sortByText: Boolean = true,
@@ -19,6 +15,10 @@ data class ChangeLogFormat(
     var changeLogPattern = "\\A(?<Type>\\w+)(?:\\((?<Scope>[^()]+)\\))?!?:\\s*(?<Message>(?:.|\n)*)"
 
     companion object {
+        const val HEADER = "#"
+        const val BREAKING_CHANGE = "!"
+        const val OTHER_CHANGE = "?"
+
         val defaultHeaderTexts = mutableMapOf(
             HEADER to "## What's Changed",
             BREAKING_CHANGE to "### Breaking Changes 🛠",


### PR DESCRIPTION
`HEADER` is a pretty much generic term that would pollute the namespace if imported by Gradle projects to customize the header. Move these constants into the companion object to be able to use e.g.

    ChangeLogFormat.defaultHeaderTexts[ChangeLogFormat.HEADER] = ""

instead of

    ChangeLogFormat.defaultHeaderTexts[HEADER] = ""