### PR TITLE
feat: Add setting to disable git-signing

### DIFF
--- a/src/main/kotlin/git/semver/plugin/scm/GitProvider.kt
+++ b/src/main/kotlin/git/semver/plugin/scm/GitProvider.kt
@@ -76,13 +76,17 @@ internal class GitProvider(private val settings: SemverSettings) {
         val isCommit = isFormatEnabled(params.commit, settings.releaseCommitTextFormat)
         if (isCommit) {
             val commitMessage = settings.releaseCommitTextFormat.format(versionString, params.message.orEmpty())
-            it.commit().setMessage(commitMessage.trim()).call()
+            val commitCommand = it.commit().setMessage(commitMessage.trim())
+            settings.gitSigning?.let(commitCommand::setSign) // Set signing if not set to null
+            commitCommand.call()
         }
 
         val isTag = isFormatEnabled(params.tag, settings.releaseTagNameFormat)
         if (isTag) {
             val name = settings.releaseTagNameFormat.format(versionString)
-            it.tag().setName(name).setMessage(params.message).call()
+            val tagCommand = it.tag().setName(name).setMessage(params.message)
+            settings.gitSigning?.let(tagCommand::setSigned) // Set signing if not set to null
+            tagCommand.call()
             println("Created new local Git tag: $name")
         }
 

--- a/src/main/kotlin/git/semver/plugin/semver/BaseSettings.kt
+++ b/src/main/kotlin/git/semver/plugin/semver/BaseSettings.kt
@@ -12,7 +12,8 @@ abstract class BaseSettings(
     var releaseTagNameFormat: String = "%s",
     var groupVersionIncrements: Boolean = true,
     var noDirtyCheck: Boolean = false,
-    var noAutoBump: Boolean = false
+    var noAutoBump: Boolean = false,
+    var gitSigning: Boolean? = null // null means use the jgit default
 ) : Serializable {
     constructor(settings: BaseSettings) : this(
         settings.defaultPreRelease, settings.releasePattern, settings.patchPattern, settings.minorPattern,


### PR DESCRIPTION
I consistently have issues with jgit and gpg signing and as far as i can see this is an issue with the way jgit handles gpg keys and mac. In order to still make the plugin usable i added an option that allows to either force a gpgsigning or to disable gpg signing even if jgit attempts it.