### PR TITLE
chore(chnagelog): Rename `message` to `description`

### DIFF
--- a/src/main/kotlin/git/semver/plugin/changelog/ChangeLogFormatter.kt
+++ b/src/main/kotlin/git/semver/plugin/changelog/ChangeLogFormatter.kt
@@ -9,7 +9,7 @@ data class ChangeLogFormatter(
     companion object {
         private const val SCOPE = "Scope"
         private const val TYPE = "Type"
-        private const val MESSAGE = "Message"
+        private const val DESCRIPTION = "Description"
     }
 
     fun formatLog(changeLog: List<Commit>, settings: SemverSettings, changeLogTexts: ChangeLogTexts): String {
@@ -57,7 +57,7 @@ data class ChangeLogFormatter(
                 isBreakingChange,
                 it.groupValue(TYPE),
                 it.groupValue(SCOPE),
-                it.groupValue(MESSAGE)
+                it.groupValue(DESCRIPTION)
             )
         } ?: CommitInfo(commits, text, isBreakingChange)
     }
@@ -70,7 +70,7 @@ data class ChangeLogFormatter(
         val isBreaking: Boolean,
         val type: String? = null,
         val scope: String? = null,
-        val message: String? = null
+        val description: String? = null
     )
 
     class Context {

--- a/src/main/kotlin/git/semver/plugin/changelog/ChangeLogTexts.kt
+++ b/src/main/kotlin/git/semver/plugin/changelog/ChangeLogTexts.kt
@@ -63,11 +63,11 @@ open class ChangeLogTexts(
 
     var sortByText: Boolean = true
 
-    var changeLogPattern: String = "(?m)^(?<Type>\\w+)(?:\\((?<Scope>[^()]+)\\))?!?:\\s*(?<Message>.*)$"
+    var changeLogPattern: String = "(?m)^(?<Type>\\w+)(?:\\((?<Scope>[^()]+)\\))?!?:\\s*(?<Description>.*)$"
 
 
     var headerFormat: (ChangeLogFormatter.CommitInfo) -> String = { commitInfo ->
-        (commitInfo.message ?: commitInfo.text).lineSequence().first()
+        (commitInfo.description ?: commitInfo.text).lineSequence().first()
     }
     var fullHeaderFormat: (ChangeLogFormatter.CommitInfo) -> String = { commitInfo ->
         commitInfo.text.lineSequence().first()


### PR DESCRIPTION
This variable should only contain the description part of the commit message title as described at [1].

[1]: https://www.conventionalcommits.org/en/v1.0.0/#summary